### PR TITLE
Several improvements to the U.S. English translation and config file descriptions

### DIFF
--- a/src/main/java/mezz/itemzoom/client/config/Config.java
+++ b/src/main/java/mezz/itemzoom/client/config/Config.java
@@ -33,7 +33,7 @@ public class Config {
 				.defineInRange("zoom.amount", DEFAULT_ZOOM, MIN_ZOOM, MAX_ZOOM, Integer.class);
 
 		jeiOnly = builder
-				.comment("Zoom items only from the JEI overlay with ingredients list.")
+				.comment("Zoom items only from the JEI ingredient list overlay.")
 				.translation("config.itemzoom.jei.only")
 				.define("jei.only", false);
 

--- a/src/main/resources/assets/itemzoom/lang/en_us.json
+++ b/src/main/resources/assets/itemzoom/lang/en_us.json
@@ -12,14 +12,14 @@
     "config.itemzoom.toggle.enabled.comment": "If set to \"false\", Item Zoom will be disabled.",
     "config.itemzoom.zoom.amount": "Zoom Amount",
     "config.itemzoom.zoom.amount.comment": "Set lower amount to make the item zoom less.",
-    "config.itemzoom.jei.only": "JEI Overlay Only",
-    "config.itemzoom.jei.only.comment": "Zoom items only from the JEI overlay with ingredients list.",
+    "config.itemzoom.jei.only": "JEI Ingredient Overlay Only",
+    "config.itemzoom.jei.only.comment": "Zoom items only from the JEI ingredient list overlay.",
     "config.itemzoom.show.help.text": "Display Help Text",
     "config.itemzoom.show.help.text.comment": "Display name \"Item Zoom\" and the hotkey to toggle this mod below the zoomed item.",
     "config.itemzoom.show.damage.bar": "Display Durability Bar",
     "config.itemzoom.show.damage.bar.comment": "Display the item's durability bar when zoomed.",
     "config.itemzoom.show.stack.size": "Display Stack Size",
     "config.itemzoom.show.stack.size.comment": "Display the item's stack size when zoomed.",
-    "config.itemzoom.show.stack.size": "Display Cooldown",
-    "config.itemzoom.show.stack.size.comment": "Display the item's cooldown animation when zoomed."
+    "config.itemzoom.show.cooldown": "Display Cooldown",
+    "config.itemzoom.show.cooldown.comment": "Display the item's cooldown animation when zoomed."
 }


### PR DESCRIPTION
For some time now, JEI has had not only the ingredient list overlay but also the bookmark overlay. Since ItemZoom works with the ingredient list overlay only, I made it clear how it works. (Isn't it a bug, though?)

Additionally, in e4389f526e717e4ec3c252fe7a2dd7e8ceb8f393 two new strings have been added, but possibly due to a copy-paste mistake, their IDs in the English translation file were not what they should be.